### PR TITLE
upgrade to xunit 2.3.1 and xbehave 2.3.0-rc0001-build717

### DIFF
--- a/.idea/.idea.MiniPie/riderModule.iml
+++ b/.idea/.idea.MiniPie/riderModule.iml
@@ -13,10 +13,10 @@
       <sourceFolder url="file://$MODULE_DIR$/../../packages/System.Runtime.Analyzers.1.1.0/analyzers/dotnet/cs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../packages/System.Runtime.InteropServices.Analyzers.1.1.0/analyzers/dotnet/cs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../packages/System.Security.Cryptography.Hashing.Algorithms.Analyzers.1.1.0/analyzers/dotnet/cs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.2.0/build/_common/xunit.abstractions.dll" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.2.0/build/_common/xunit.runner.reporters.net452.dll" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.2.0/build/_common/xunit.runner.utility.net35.dll" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.2.0/build/_common/xunit.runner.visualstudio.testadapter.dll" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.3.1/build/_common/xunit.abstractions.dll" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.3.1/build/_common/xunit.runner.reporters.net452.dll" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.3.1/build/_common/xunit.runner.utility.net35.dll" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../packages/xunit.runner.visualstudio.2.3.1/build/_common/xunit.runner.visualstudio.testadapter.dll" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../README.md" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/../../MiniPie.Core/bin" />
       <excludeFolder url="file://$MODULE_DIR$/../../MiniPie.Core/obj" />

--- a/MiniPie.Tests/MiniPie.Tests.csproj
+++ b/MiniPie.Tests/MiniPie.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.runner.msbuild.2.2.0\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\packages\xunit.runner.msbuild.2.2.0\build\net452\xunit.runner.msbuild.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props')" />
+  <Import Project="..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -99,23 +101,23 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="Xbehave.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Core.dll</HintPath>
+    <Reference Include="Xbehave.Core, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xbehave.Core.2.3.0-rc0001-build717\lib\net452\Xbehave.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Execution.desktop, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Execution.desktop.dll</HintPath>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xbehave.Core.2.3.0-rc0001-build717\lib\net452\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -157,15 +159,23 @@
       <Name>MiniPie</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.msbuild.2.2.0\build\net452\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.msbuild.2.2.0\build\net452\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
+  <Import Project="..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.targets" Condition="Exists('..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MiniPie.Tests/app.config
+++ b/MiniPie.Tests/app.config
@@ -8,11 +8,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />

--- a/MiniPie.Tests/packages.config
+++ b/MiniPie.Tests/packages.config
@@ -13,15 +13,16 @@
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net461" />
-  <package id="Xbehave" version="2.2.0-beta0003-build685" targetFramework="net452" />
-  <package id="Xbehave.Core" version="2.2.0-beta0003-build685" targetFramework="net452" />
-  <package id="xunit" version="2.2.0" targetFramework="net452" />
+  <package id="Xbehave" version="2.3.0-rc0001-build717" targetFramework="net461" />
+  <package id="Xbehave.Core" version="2.3.0-rc0001-build717" targetFramework="net461" />
+  <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.runner.console" version="2.2.0" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.msbuild" version="2.2.0" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.msbuild" version="2.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ notifications:
       secure: l9d2Z7yxqHY6S1Iom6FANSPbVpIcz0zes2lw6DmedTdqfgJRf10nVXSRp2YAMwVy
     channel: '#appveyor'
 test_script:
-  - cmd: packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:+"[MiniPie*]MiniPie* -[MiniPie.Tests]* -[MiniPie*]*.Properties* -[MiniPie*]MiniPie.Views* -[MiniPie*]MiniPie.Interactivity* -[MiniPie.Core]MiniPie.Core.SpotifyNative*" -target:packages\xunit.runner.console.2.2.0\tools\xunit.console.exe -targetargs:"MiniPie.Tests\bin\Release\MiniPie.Tests.dll -noshadow -appveyor -xml xunit-results.xml" -output:coverage.xml -returntargetcode
+  - cmd: packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:+"[MiniPie*]MiniPie* -[MiniPie.Tests]* -[MiniPie*]*.Properties* -[MiniPie*]MiniPie.Views* -[MiniPie*]MiniPie.Interactivity* -[MiniPie.Core]MiniPie.Core.SpotifyNative*" -target:packages\xunit.runner.console.2.3.1\tools\net452\xunit.console.exe -targetargs:"MiniPie.Tests\bin\Release\MiniPie.Tests.dll -noshadow -appveyor -xml xunit-results.xml" -output:coverage.xml -returntargetcode
   #- ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\xunit-results.xml))
 after_test:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"


### PR DESCRIPTION
Some background: before releasing xbehave 2.3.0 RTM, I'm attempting to find projects who would be willing to test the release candidate. This PR upgrades xbehave to 2.3.0-rc0001 (which also requires an upgrade to the latest xunit, which is 2.3.1).

I tested everything locally and the tests pass. Note that an xbehave RC is a _true RC_. I.e. it is RTM quality and if no bugs are found, 2.3.0 RTM will be released with a build from the same source code as the latest 2.3.0 RC. Therefore the risk of using an RC (which is, after all, still a pre-release) should be very low, but of course, it's up to you whether you want to merge this PR. 😉

Regardless, thanks for using xbehave, I hope you're enjoying it. 👍 